### PR TITLE
Fix Identity Server Analytics dashboard health check path error

### DIFF
--- a/is-with-analytics/is-with-analytics.yaml
+++ b/is-with-analytics/is-with-analytics.yaml
@@ -1504,7 +1504,7 @@ Resources:
       HealthCheckProtocol: HTTPS
       HealthCheckTimeoutSeconds: 10
       HealthyThresholdCount: 2
-      HealthCheckPath: /portal
+      HealthCheckPath: /portal/
       HealthCheckPort: 9643
       Matcher:
         HttpCode: 200


### PR DESCRIPTION
## Purpose
Fix Identity Server Analytics dashboard health check path error

## Goals
Change the Healthcheck path from /portal to /portal/

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
