### PR TITLE
Fix cluster deployment proxy port issue

### DIFF
--- a/Minimum-HA/scalable-is.yaml
+++ b/Minimum-HA/scalable-is.yaml
@@ -1136,17 +1136,17 @@ Parameters:
 Mappings:
   WSO2PuppetMasterRegionMap:
     ap-southeast-2:
-      Ubuntu1804: ami-0d6ae63a70287e870
+      Ubuntu1804: ami-05d7dd19f55192eaa
     eu-west-1:
-      Ubuntu1804: ami-096609b3f2c899c59
+      Ubuntu1804: ami-0b020d57cd13fe860
     us-east-1:
-      Ubuntu1804: ami-04a6ce6c2cc75ed78
+      Ubuntu1804: ami-01cc5ffe6c88ebc23
     us-east-2:
-      Ubuntu1804: ami-0ac3a1112369ccfcb
+      Ubuntu1804: ami-02f90092c2119e421
     us-west-1:
-      Ubuntu1804: ami-016a850b8b9b8e7fe
+      Ubuntu1804: ami-07a0f472a57807626
     us-west-2:
-      Ubuntu1804: ami-08c8f175096621578 
+      Ubuntu1804: ami-01cfc5c925a6d263a
   WSO2ISAMIRegionMap:
     ap-southeast-2:
       CentOS7: ami-0211f0ecd0e693937


### PR DESCRIPTION
## Purpose
Fix the Catalina server.xml proxy ports not getting set issue.

## Goals
Change the code to the followings.
```
[transport.http.properties]
proxyPort = "<%= @http_proxy_port %>"

[transport.https.properties]
proxyPort = "<%= @https_proxy_port %>"
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
https://github.com/wso2-support/puppet-is/pull/18

## Test environment
AWS